### PR TITLE
Replace HW timer 2 with HW timer 1 as micro-second part in time. 

### DIFF
--- a/gos_main.c
+++ b/gos_main.c
@@ -185,6 +185,7 @@ void os_main(void)
 	us_timer_init();
 
 	/* set up a isr for HW timer 2. */
+	timer1_init();
 	irq_reg(5, os_timer_isr, 0, SHARED_IRQ); 
 
 	/* Setup System Timer. */

--- a/gos_main.c
+++ b/gos_main.c
@@ -18,10 +18,6 @@ extern void gos_printf(const char* format, ...);
 spinlock_t test = spinlock_locked;
 static unsigned int gos_cpu_info = 0x0;
 
-extern int timer_init (void);
-extern int timer1_init (void);
-extern void vic_init2(void *base);
-
 void print_cpuinfo(void)
 {
 #define L1_DCache	(1 << 2)
@@ -185,8 +181,10 @@ void os_main(void)
 	/* init irq mechanism. */
 	irq_init();
 
+	/* set up us timer */
+	us_timer_init();
+
 	/* set up a isr for HW timer 2. */
-	timer1_init();
 	irq_reg(5, os_timer_isr, 0, SHARED_IRQ); 
 
 	/* Setup System Timer. */

--- a/gos_timer.c
+++ b/gos_timer.c
@@ -41,7 +41,7 @@ int timer_init (void)
 	return 0;
 }
 
-int timer1_init (void)
+int us_timer_init (void)
 {
 	unsigned long	tmr_ctrl_val;
 
@@ -63,7 +63,7 @@ int timer1_init (void)
 	return 0;
 }
 
-void timer1_curval(unsigned long * val)
+void us_timer_curval(unsigned long * val)
 {
         void *reg;
 

--- a/gos_timer.c
+++ b/gos_timer.c
@@ -27,7 +27,7 @@ int timer_init (void)
 	*(volatile unsigned long *)(CONFIG_SYS_TIMERBASE + 8) = tmr_ctrl_val;
 
 	/* 10ms timer load. */
-	tmr_ctrl_val = 10000;	
+	tmr_ctrl_val = 10000;
 	//tmr_ctrl_val = 1000000;	
 
 	*(volatile unsigned long *)(CONFIG_SYS_TIMERBASE + 0) = tmr_ctrl_val;
@@ -41,6 +41,27 @@ int timer_init (void)
 	return 0;
 }
 
+int timer1_init (void)
+{
+	unsigned long	tmr_ctrl_val;
+
+	/* 1st disable the Timer */
+	tmr_ctrl_val = *(volatile unsigned long *)(CONFIG_SYS_TIMER1BASE + 8);
+	tmr_ctrl_val &= ~TIMER_ENABLE;
+	*(volatile unsigned long *)(CONFIG_SYS_TIMER1BASE + 8) = tmr_ctrl_val;
+
+	/* 1 sec timer load. */
+	tmr_ctrl_val = 1000000;
+
+	*(volatile unsigned long *)(CONFIG_SYS_TIMER1BASE + 0) = tmr_ctrl_val;
+
+	tmr_ctrl_val = *(volatile unsigned long *)(CONFIG_SYS_TIMER1BASE + 8);
+	tmr_ctrl_val &= ~(TIMER_MODE_MSK | TIMER_INT_EN | TIMER_PRS_MSK | TIMER_SIZE_MSK | TIMER_MODE_PD);
+	tmr_ctrl_val |= (TIMER_ENABLE | TIMER_INT_EN | TIMER_ONE_SHT);
+	*(volatile unsigned long *)(CONFIG_SYS_TIMER1BASE + 8) = tmr_ctrl_val;
+
+	return 0;
+}
 int us_timer_init (void)
 {
 	unsigned long	tmr_ctrl_val;

--- a/inc/timer.h
+++ b/inc/timer.h
@@ -4,9 +4,9 @@
 #define TIMER1_LOAD_VAL 1000000
 
 int timer_init (void);
-int timer1_init (void);
+int us_timer_init (void);
 void vic_init2(void *base);
-void timer1_curval(unsigned long * val);
+void us_timer_curval(unsigned long * val);
 inline void udelay(unsigned long count);
 
 #endif /* __timer_h__ */

--- a/inc/timer.h
+++ b/inc/timer.h
@@ -4,6 +4,7 @@
 #define TIMER1_LOAD_VAL 1000000
 
 int timer_init (void);
+int timer1_init (void);
 int us_timer_init (void);
 void vic_init2(void *base);
 void us_timer_curval(unsigned long * val);

--- a/time.c
+++ b/time.c
@@ -9,7 +9,7 @@ int _gettimeofday( struct timeval *tv, void *tzvp )
 	unsigned long t = 0;
 
 	rtc_read(&sec);
-	timer1_curval(&us);
+	us_timer_curval(&us);
 	t = (sec * 1000000) + (TIMER1_LOAD_VAL - us);  // timer1 decrease to 0, get uptime in us
 	tv->tv_sec = t / 1000000;  // convert to seconds
 	tv->tv_usec = ( t % 1000000 ) ;  // get remaining microseconds


### PR DESCRIPTION
Currently, we use hw timer 1 as micro-second part in time. We should change it as following arrangement.

HW timer 0 : system timer (scheduler)      Enable Interrupt
HW timer 1 : micro-second part in time     Disable Interrupt
HW timer 2 : OS timer1                             Enable Interrupt
HW timer 3 : OS timer2                             Enable Interrupt
